### PR TITLE
refit submodels before fitting resamples

### DIFF
--- a/R/modeltime_refit.R
+++ b/R/modeltime_refit.R
@@ -94,6 +94,7 @@ mdl_time_refit.mdl_time_ensemble_model_spec <- function(object, data, ..., contr
 
         # Fit the resamples
         model_resample_tbl <- model_tbl %>%
+            modeltime::modeltime_refit(data) %>%
             modeltime.resample::modeltime_fit_resamples(
                 resamples = resamples,
                 control   = control_rsmpl


### PR DESCRIPTION
When making final predictions for a stacking ensemble, all submodels need to be refitted on full dataset before calling modeltime_fit_resamples, otherwise the stacking ensemble predictions obtained with modeltime_refit will be problematic, especially if there is a trend in the time series.

I don't know if this commit is the best solution to the problem,  but it seems to be a simple imediate solution. I have made this gist to illustrate the problem: https://gist.github.com/regisely/435d4a2d444c44bd83bb8669d163f4f9